### PR TITLE
This adds libocaml-ounit-dev to build deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xen-api-libs (0.5-3) unstable; urgency=low
+
+  * Upstream has new build dependency on libounit-ocaml-dev
+
+ -- Mike McClurg <mike.mcclurg@citrix.com>  Thu, 17 Nov 2011 15:20:05 +0000
+
 xen-api-libs (0.5-2) unstable oneiric; urgency=low
 
   * Fix control file following renaming of the blktap packages

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: xen-api-libs
 Section: libs
 Priority: extra
 Maintainer: Jon Ludlam <jonathan.ludlam@eu.citrix.com>
-Build-Depends: debhelper (>= 8.0.0), libxen-ocaml-dev, libxen-ocaml-4.1, ocaml-nox, camlp4, camlp4-extra, ocaml-findlib, autotools-dev, dh-autoreconf, libtype-conv-camlp4-dev, libxmlm-ocaml-dev, uuid-dev, libdevmapper-dev, libxen-dev, blktap-dev, dh-ocaml
+Build-Depends: debhelper (>= 8.0.0), libxen-ocaml-dev, libxen-ocaml-4.1, ocaml-nox, camlp4, camlp4-extra, ocaml-findlib, autotools-dev, dh-autoreconf, libtype-conv-camlp4-dev, libxmlm-ocaml-dev, uuid-dev, libdevmapper-dev, libxen-dev, blktap-dev, dh-ocaml, libounit-ocaml-dev
 Standards-Version: 3.9.2
 Homepage: http://www.xen.org/XCP
 #Vcs-Git: git://git.debian.org/collab-maint/xen-api-libs.git

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: Jon Ludlam <jonathan.ludlam@eu.citrix.com>
 Build-Depends: debhelper (>= 8.0.0), libxen-ocaml-dev, libxen-ocaml-4.1, ocaml-nox, camlp4, camlp4-extra, ocaml-findlib, autotools-dev, dh-autoreconf, libtype-conv-camlp4-dev, libxmlm-ocaml-dev, uuid-dev, libdevmapper-dev, libxen-dev, blktap-dev, dh-ocaml, libounit-ocaml-dev
 Standards-Version: 3.9.2
 Homepage: http://www.xen.org/XCP
-#Vcs-Git: git://git.debian.org/collab-maint/xen-api-libs.git
-#Vcs-Browser: http://git.debian.org/?p=collab-maint/xen-api-libs.git;a=summary
+Vcs-Git: git://github.com/xen-org/xen-api-libs.git
+Vcs-Browser: https://github.com/xen-org/xen-api-libs/
 
 Package: libxcp-ocaml
 Architecture: any


### PR DESCRIPTION
But it looks like I've rebased this branch too many times, and it's going to be ugly when you pull this. Feel free to cherry-pick the last two commits, if it gets too hairy.

Mike
